### PR TITLE
aggiornamento file swagger

### DIFF
--- a/docs/openapi/api-external-b2b-webhook-v1.yaml
+++ b/docs/openapi/api-external-b2b-webhook-v1.yaml
@@ -1,58 +1,190 @@
+# di seguito le variabili che possono subire variazioni in caso di modifiche all'applicazione, da ricercare in base all'ID
+# <span id="webhookMaxLength">10</span> pn.delivery-push.webhook.max-length = lunghezza massima della response degli eventi
+# <span id="webhookMaxStreams">5</span> pn.delivery-push.webhook.max-streams = numero massimo di stram confgurabili per PA
+# <span id="webhookTtl">7</span> pn.delivery-push.webhook.ttl = retention per gli eventi webhook PN-2264
 openapi: 3.0.3
 info:
-  termsOfService: https://termofservice.it
-  title: 'API B2B avanzamento notifiche'
+  termsOfService: https://notifichedigitali.pagopa.it/pubbliche-amministrazioni/index.html
+  title: 'Piattaforma Notifiche: API B2B avanzamento notifiche'
   x-summary: 'API B2B avanzamento notifiche'
   version: '1.0.0'
-  x-api-id: api-internal-b2b-webhook
+  x-api-id: api-external-b2b-webhook # ONLY EXTERNAL
   description: >- 
     I mittenti di notifica possono seguire il flusso di avanzamento delle notifiche in modo 
-    automatico. E' possibile definire fino ad un massimo di 5 configurazioni di flussi per 
+    automatico. E' possibile definire fino ad un <font color="red"><strong>massimo di <span id="webhookMaxStreams">5</span> configurazioni di flussi</strong></font> per 
     informazioni relative a: <br/>
       - cambiamento di stato della notifica;  <br/>
       - inserimento di elementi nella timeline. <br/>
     
     Per ognuno di questi elementi è possibile definire un filtro per ricevere solo alcuni 
-    cambiamenti di stato o determinati eventi di timeline.
-    
-    Esempio:
-    - Ricezione dell'accettazione o rifiuto delle notifiche:
-    
+    cambiamenti di stato o determinati eventi di timeline di maggiore interesse. Si consiglia 
+    di creare gli stream prima dell'invio delle notifiche perchè gli stati o gli eventi di 
+    timeline vengono registrati solo successivamente alla creazione dello stream.</br>
+    </br>
+    __Esempio:__
+    - Stream contenente tutte le notifiche in stato Cancellato:
+    </br></br>
     ``
     {
-      "title": "NotificationAccepted",
+      "title": "NotificationCancelled",
       "eventType": "STATUS",
       "filterValues": [
-        "ACCEPTED","
+        "CANCELLED"
       ]
     }
     ``
+    </br></br>
+    __Esempio:__
+    - Stream contenente tutte le notifiche in stato Accettato o Consegnato:
+    </br></br>
+    ``
+    {
+      "title": "NotificationAcceptedOrDelivered",
+      "eventType": "STATUS",
+      "filterValues": [
+        "ACCEPTED","DELIVERED"
+      ]
+    }
+    ``
+    </br></br>
+    __Esempio:__
+    - Stream contenente tutti gli eventi di timeline NOTIFICATION_VIEWED:
+    </br></br>
+    ``
+    {
+      "title": "TimelineNotificationViewed",
+      "eventType": "TIMELINE",
+      "filterValues": [
+        "NOTIFICATION_VIEWED"
+      ]
+    }
+    ``
+    </br></br>
     
-    Gli stati della notifica sono: $ref: './schemas-pn-status-v1.yaml#/components/schemas/NotificationStatus'
-    
-    Le categorie degli eventi di timeline sono:  $ref: './schemas-pn-timeline-v1.yaml#/components/schemas/TimelineElementCategory'
-    
-    Le operazioni con il tag __Streams__ gestiscono la configurazione: <br/>
-      - Creazione; <br/>
-      - Modifica; <br/>
-      - Cancellazione. <br/>
+    Gli stati della notifica sono i seguenti: 
+      <details>
+        <summary>Stati</summary>
+        <ul>
+          <li><strong>IN_VALIDATION </strong><em>notifica depositata in attesa di validazione.</em></li>
+          <li><strong>ACCEPTED </strong><em>L'ente ha depositato la notifica con successo.</em></li>
+          <li><strong>REFUSED </strong><em>Notifica rifiutata a seguito della validazione.</em></li>
+          <li><strong>DELIVERING </strong><em>L'invio della notifica è in corso.</em></li>
+          <li><strong>DELIVERED </strong><em>La notifica è stata consegnata a tutti i destinatari.</em></li>
+          <li><strong>VIEWED </strong><em>Il destinatario ha letto la notifica entro il termine stabilito.</em></li>
+          <li><strong>EFFECTIVE_DATE </strong><em>Il destinatario non ha letto la notifica entro il termine stabilito.</em></li>
+          <li><strong>PAID </strong><em>Uno dei destinatari ha pagato la notifica.</em></li>
+          <li><strong>UNREACHABLE </strong><em>Il destinatario non è reperibile.</em></li>
+          <li><strong>CANCELLED </strong><em>L'ente ha annullato l'invio della notifica.</em></li>
+        </ul>
+      </details>
+    </br>
 
-    Le operazioni con il tag __Events__ sono quelle utilizzate per la lettura degli eventi 
+    Le categorie degli eventi di timeline sono i seguenti: 
+
+      <details>
+        <summary>Eventi di timeline</summary>
+        <ul>
+          <li><strong>REQUEST_REFUSED </strong><em>Richiesta di notifica rifiutata per fallimento di validazione.</em></li>
+          <li><strong>REQUEST_ACCEPTED </strong><em>Richiesta di notifica accettata a seguito dei controlli di validazione.</em></li>
+          <li><strong>SEND_COURTESY_MESSAGE </strong><em>Invio di un messaggio di cortesia.</em></li>
+          <li><strong>PUBLIC_REGISTRY_CALL </strong><em>Richiesta ai registri pubblici per ottenere domicilio digitale generale o per ottenere indirizzo fisico da ANPR, da registro della imprese, da anagrafe tributaria.</em></li>
+          <li><strong>PUBLIC_REGISTRY_RESPONSE </strong><em>Ricevuta la risposta dei registri pubblici.</em></li>
+          <li><strong>GET_ADDRESS </strong><em>Disponibilità dell’indirizzo specifico (domicilio digitale di piattaforma, domicilio digitale speciale, domicilio digitale generale, indirizzo fisico sulla notifica o sui registri nazionali).</em></li>
+          <li><strong>SCHEDULE_ANALOG_WORKFLOW </strong><em>Inizio del workflow per invio cartaceo.</em></li>
+          <li><strong>SCHEDULE_DIGITAL_WORKFLOW </strong><em>Inizio il workflow per invio digitale (PEC).</em></li>
+          <li><strong>SEND_DIGITAL_DOMICILE </strong><em>Invio digitale dell’avviso di notifica</em></li>
+          <li><strong>SEND_DIGITAL_FEEDBACK </strong><em>Ottenuto esito ad un invio digitale</em></li>
+          <li><strong>SCHEDULE_REFINEMENT </strong><em>Pianificato il perfezionamento per decorrenza termini</em></li>
+          <li><strong>REFINEMENT </strong><em>Perfezionamento per decorrenza termini</em></li>
+          <li><strong>DIGITAL_SUCCESS_WORKFLOW </strong><em>Completato con successo il workflow di invio digitale.</em></li>
+          <li><strong>DIGITAL_FAILURE_WORKFLOW </strong><em>Completato con fallimento il workflow di invio digitale. <strong>NOTA</strong>: in caso di DIGITAL_FAILURE_WORKFLOW piattaforma notifiche invia la AAR (Avviso di Avvenuta Ricezione) tramite raccomandata semplice e la notifica si considera consegnata.</em></li>
+          <li><strong>ANALOG_SUCCESS_WORKFLOW </strong><em>Completato con successo il workflow di invio cartaceo.</em></li>
+          <li><strong>ANALOG_FAILURE_WORKFLOW </strong><em>Completato con fallimento il workflow di invio cartaceo. <strong>NOTA</strong>: se per tutti i destinatari si conclude il workflow con fallimento verrà scatenato l’evento COMPLETELY_UNREACHABLE</em></li>
+          <li><strong>SEND_SIMPLE_REGISTERED_LETTER </strong><em>Invio di raccomandata semplice</em></li>
+          <li><strong>NOTIFICATION_VIEWED </strong><em>Perfezionamento per presa visione</em></li>
+          <li><strong>SEND_ANALOG_DOMICILE </strong><em>Invio cartaceo dell’avviso di notifica</em></li>
+          <li><strong>SEND_PAPER_FEEDBACK </strong><em>Ricezione esito dell'invio cartaceo</em></li>
+          <li><strong>COMPLETELY_UNREACHABLE </strong><em>Tutti i destinatari risultano irraggiungibili</em></li>
+          <li><strong>AAR_GENERATION </strong><em>Generazione dell’AAR (Avviso di Avvenuta Ricezione)</em></li>
+          <li><strong>PAYMENT </strong><em>Ricezione pagamento della notifica</em></li>
+          <li><strong>NOT_HANDLED </strong><em>Per la sperimentazione l'invio analogico non è previsto, viene inserito tale elemento di timeline</em></li>
+        </ul>
+      </details>
+    </br>
+
+    Le operazioni con il tag __Streams__ gestiscono la configurazione: <br/>
+      - [Creazione](#/Streams/createEventStream) <br/>
+      - [Elencare la lista degli stream creati](#/Streams/listEventStreams) <br/>
+      - [Leggere i metadati dello stream](#/Streams/getEventStream) <br/>
+      - [Modifica](#/Streams/updateEventStream) <br/>
+      - [Cancellazione](#/Streams/deleteEventStream) <br/>
+
+    Le operazioni con il tag __Events__ sono quelle utilizzate per la [lettura degli eventi](#/Events/consumeEventStream) 
     filtrati in base alla configurazione impostata negli streams.
     
-    La api restituisce un massimo di 100 elementi. Se ci sono ulteriori eventi nello stream sarà restituito 
-    l'elemento `retryAfter = 0`, per ottenere gli eventi successivi è necessario richiamare il servizio 
-    passando il parametro _lastEventId_ valorizzato con l'ultimo _eventId_ della richiesta precedente.
-    Questo permetterà alla piattaforma di cancellare gli eventi precedenti.
+    La api restituisce un massimo di <span id="webhookMaxLength">10</span> elementi. Se <u>esistono</u> ulteriori eventi nello stream, allora la response del servizio 
+    restituice l'elemento `retryAfter = 0`; ed è quindi possibile richiamare immediatamente il servizio per ottenere gli eventi successivi, utilizzando 
+    il parametro _lastEventId_ valorizzato con l'ultimo _eventId_ della richiesta precedente.
+    Si evidenzia che ogni nuova chiamata al servizio con _lastEventId_ implica la cancellazione degli eventi precedenti.
+    Tuttavia, in fase di implementazione del client che consumerà i servizi, bisogna considerare il fattore della __non univocità degli eventi__: è possibile che
+    se in un dato secondo avvengano più eventi contemporaneamente, nella chiamata successiva allo stream dove si inserisce l'_eventId_, non vengano cancellati
+    gli altri eventi contemporanei avvenuti nello stesso secondo dell'_eventId_ indicato; ottenendo quindi una riproposizione di eventi già ottenuti dalla chiamata precedente.</br>
+    Se <u>non esistono</u> ulteriori eventi nello stream, allora la response del servizio restituisce il valore di `retryAfter ≠ 0` ed è quindi necessario attendere il tempo indicato dalla retryAfter per consumare eventualmente nuovi eventi nello stream.</br>
+    <font color="red">__Gli eventi sono mantenuti per un massimo di <span id="webhookTtl">7</span> giorni dopo i quali sono automaticamente cancellati anche se non sono stati prelevati dallo stream, e sarà possibile ottenere lo stato della notifica solo attraverso il servizio [getNotificationRequestStatus](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/pagopa/pn-delivery/develop/docs/openapi/api-external-b2b-pa-v1.yaml#/SenderReadB2B/retrieveNotificationRequestStatus)__ </font> 
+
+    </br>
+    </br>
+    </br>
+
+    <details>
+      <summary><strong><big><big><big><big>FAQ</big></big></big></big></strong></summary>
+
+      ><details>
+      <summary><strong>Cosa devo fare se ricevo</strong> `{"message": "Unauthorized"}`<strong>?</strong></summary>
+      <em>Il messaggio indica che non sono disponibili le credenziali per utilizzare i servizi di PN. Per intraprendere il processo di accreditamento, occorre contattare il personale preposto su [account@pagopa.it](mailto:account@pagopa.it)</em>
+      </details>
+
+      ><details>
+      <summary><strong>Se creo uno stream senza filtri ad esempio</strong></br>`{ "title": "NoFilteredStream", "eventType": "STATUS", "filterValues": [] }`</br><strong> questo raccoglierà tutti i cambi di stato avvenuti nel tempo?</strong></summary>
+      <em>SI. Questo concetto è valido anche per gli eventi di TIMELINE.</em>
+      </details>
+
+      ><details>
+      <summary><strong>E' meglio avere più stream filtrati, per inquadrare specifici eventi di interesse?</strong></summary>
+      <em>SI, è consigliato generare uno o più stream applicando i filtri sugli eventi di status / timeline di maggior interesse, 
+      <font color="red"><strong>restando nel limite massimo di <span id="webhookMaxStreams">5</span> 
+      stream per PA.</font></strong></em>
+      </details>      
+
+      ><details>
+      <summary><strong>Dopo aver creato uno stream ed inserite alcune notifiche, come posso vedere gli eventi da esse generati?</strong></summary>
+      <em>Per ottenere gli eventi bisogna chiamare il servizio per la [lettura degli eventi](#/Events/consumeEventStream) inserendo nel path variabile lo _streamId_ dello stream che si vuole interrogare. A questo punto:</br>
+      >><strong>1) </strong>Se nell'header della response ottengo <strong>retry-after = 0</strong> significa che è possibile consumare ulteriori eventi presenti nello stream;</br> quindi, per ottenere gli eventi successivi dovrò richiamare nuovamente lo stesso servizio, aggiungendo come query param l'<strong>eventId</strong> dell'ultimo evento.</br></br>
+      <strong>2) </strong>Se nell'header della response ottengo <strong>retryAfter ≠ 0</strong> ed ho eventi nel body della response, significa che lo stream non contiene altri eventi e sarà necessario</br> attendere che ne siano generati di nuovi, prima di poter richiamare di nuovamente il servizio sullo stesso stream.</em></br></br>
+      </details>      
+
+      ><details>
+      <summary><strong>Posso ottenere più di <span id="webhookMaxLength">10</span> eventi da una singola chiamata?</strong></summary>
+      <em>NO, questo valore è configurato pari a <span id="webhookMaxLength">10</span> a livello applicativo e non può essere modificato.</em>
+      </details> 
+
+      ><details>
+      <summary><strong>Ho interrogato uno stream inserendo come path variabile lo _streamId_ di mio interesse ed ho ottenuto <span id="webhookMaxLength">10</span> eventi, ognuno con il proprio _eventId_. Ho richiamato di nuovo lo stesso servizio aggiungendo come query param l'_eventId_ dell'ultimo evento ottenuto nella prima chiamata ed ottengo gli eventi successivi a quelli ottenuti nella prima chiamata. Posso vedere di nuovo gli eventi ottenuti dalla prima chiamata?</strong></summary>
+      <em>NO, una volta passato il query param __eventId__ alla chiamata del servizio, tutti gli eventi precedenti sono cancellati dallo stream e non possono più essere recuperati. E' quindi fondamentale salvare gli eventi ottenuti da ogni chiamata, prima di richiedere i successivi.</em></br></br>
+      </details> 
+
+      ><details><summary><strong>Per quanto tempo gli eventi restano registrati su uno stream?</strong></summary><em>Gli eventi restano registrati su uno stream per <strong><span id="webhookTtl">7</span> 
+      giorni</strong>, trascorsi i quali non potranno più essere recuperati. A questo punto sarà possibile ottenere lo stato della notifica solo attraverso il servizio puntuale [getNotificationRequestStatus](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/pagopa/pn-delivery/develop/docs/openapi/api-external-b2b-pa-v1.yaml#/SenderReadB2B/retrieveNotificationRequestStatus), mentre se si conosce lo IUN si può utilizzare il servizio [getSentNotification](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/pagopa/pn-delivery/develop/docs/openapi/api-external-b2b-pa-v1.yaml#/SenderReadB2B/retrieveSentNotification) per leggere tutti i dettagli di una notifica accettata</em></details>
+
+    </details>
+
     
-    Gli eventi sono mantenuti per un massimo di X giorni dopo i quali sono automaticamente cancellati anche
-    se non sono stati prelevati dallo stream.
 
   contact:
-    email: pn@pagopa.it
+    email: pn-supporto-enti@pagopa.it
   license:
     name: Licenza di PN
-    url: 'https://da-definire/'
+    url: 'https://notifichedigitali.pagopa.it/pubbliche-amministrazioni/index.html'
 servers:
 - url: https://api.pn.pagopa.it
   description: Ambiente di produzione
@@ -262,7 +394,7 @@ paths:
                 type: integer
                 format: int32
               description: >-
-                Numero di secondi di attesa prima di effettuare una nuova lettura di eventi. <br/>
+                Numero di millisecondi di attesa prima di effettuare una nuova lettura di eventi. <br/>
                 Sarà valorizzato a zero se ci sono eventi in coda che non sono stati forniti per 
                 raggiunta dimensione massima della risposta. <br/>
                 Sarà maggiore di zero se gli eventi in coda sono stati tutti inviati.
@@ -278,7 +410,7 @@ paths:
                 type: integer
                 format: int32
               description: >-
-                Numero di secondi di attesa prima di effettuare una nuova lettura di eventi.
+                Numero di millisecondi di attesa prima di effettuare una nuova lettura di eventi.
         '400':
           description: Invalid input
           content:
@@ -431,7 +563,7 @@ components:
           type: string
         iun:
           description: >-
-            Identificativo della notifica, presente solo se la richiesta di notifica è
+            Identificativo della notifica, presente solo se la richiesta di notifica è 
             stata accettata.
           type: string
 
@@ -442,7 +574,7 @@ components:
     
     ###  - EVENTI GENERATI DALLA P.A.
     ###################################
-    
+
     
         
   

--- a/docs/openapi/api-internal-b2b-webhook-v1.yaml
+++ b/docs/openapi/api-internal-b2b-webhook-v1.yaml
@@ -1,58 +1,191 @@
+# di seguito le variabili che possono subire variazioni in caso di modifiche all'applicazione, da ricercare in base all'ID
+# <span id="webhookMaxLength">10</span> pn.delivery-push.webhook.max-length = lunghezza massima della response degli eventi
+# <span id="webhookMaxStreams">5</span> pn.delivery-push.webhook.max-streams = numero massimo di stram confgurabili per PA
+# <span id="webhookTtl">7</span> pn.delivery-push.webhook.ttl = retention per gli eventi webhook PN-2264
 openapi: 3.0.3
 info:
-  termsOfService: https://termofservice.it
-  title: 'API B2B avanzamento notifiche'
+  termsOfService: https://notifichedigitali.pagopa.it/pubbliche-amministrazioni/index.html
+  title: 'Piattaforma Notifiche: API B2B avanzamento notifiche'
   x-summary: 'API B2B avanzamento notifiche'
   version: '1.0.0'
-  x-api-id: api-internal-b2b-webhook
+  x-api-id: api-internal-b2b-webhook # NO EXTERNAL
+#  x-api-id: api-external-b2b-webhook # ONLY EXTERNAL
   description: >- 
     I mittenti di notifica possono seguire il flusso di avanzamento delle notifiche in modo 
-    automatico. E' possibile definire fino ad un massimo di 5 configurazioni di flussi per 
+    automatico. E' possibile definire fino ad un <font color="red"><strong>massimo di <span id="webhookMaxStreams">5</span> configurazioni di flussi</strong></font> per 
     informazioni relative a: <br/>
       - cambiamento di stato della notifica;  <br/>
       - inserimento di elementi nella timeline. <br/>
     
     Per ognuno di questi elementi è possibile definire un filtro per ricevere solo alcuni 
-    cambiamenti di stato o determinati eventi di timeline.
-    
-    Esempio:
-    - Ricezione dell'accettazione o rifiuto delle notifiche:
-    
+    cambiamenti di stato o determinati eventi di timeline di maggiore interesse. Si consiglia 
+    di creare gli stream prima dell'invio delle notifiche perchè gli stati o gli eventi di 
+    timeline vengono registrati solo successivamente alla creazione dello stream.</br>
+    </br>
+    __Esempio:__
+    - Stream contenente tutte le notifiche in stato Cancellato:
+    </br></br>
     ``
     {
-      "title": "NotificationAccepted",
+      "title": "NotificationCancelled",
       "eventType": "STATUS",
       "filterValues": [
-        "ACCEPTED","
+        "CANCELLED"
       ]
     }
     ``
+    </br></br>
+    __Esempio:__
+    - Stream contenente tutte le notifiche in stato Accettato o Consegnato:
+    </br></br>
+    ``
+    {
+      "title": "NotificationAcceptedOrDelivered",
+      "eventType": "STATUS",
+      "filterValues": [
+        "ACCEPTED","DELIVERED"
+      ]
+    }
+    ``
+    </br></br>
+    __Esempio:__
+    - Stream contenente tutti gli eventi di timeline NOTIFICATION_VIEWED:
+    </br></br>
+    ``
+    {
+      "title": "TimelineNotificationViewed",
+      "eventType": "TIMELINE",
+      "filterValues": [
+        "NOTIFICATION_VIEWED"
+      ]
+    }
+    ``
+    </br></br>
     
-    Gli stati della notifica sono: $ref: './schemas-pn-status-v1.yaml#/components/schemas/NotificationStatus'
-    
-    Le categorie degli eventi di timeline sono:  $ref: './schemas-pn-timeline-v1.yaml#/components/schemas/TimelineElementCategory'
-    
-    Le operazioni con il tag __Streams__ gestiscono la configurazione: <br/>
-      - Creazione; <br/>
-      - Modifica; <br/>
-      - Cancellazione. <br/>
+    Gli stati della notifica sono i seguenti: 
+      <details>
+        <summary>Stati</summary>
+        <ul>
+          <li><strong>IN_VALIDATION </strong><em>notifica depositata in attesa di validazione.</em></li>
+          <li><strong>ACCEPTED </strong><em>L'ente ha depositato la notifica con successo.</em></li>
+          <li><strong>REFUSED </strong><em>Notifica rifiutata a seguito della validazione.</em></li>
+          <li><strong>DELIVERING </strong><em>L'invio della notifica è in corso.</em></li>
+          <li><strong>DELIVERED </strong><em>La notifica è stata consegnata a tutti i destinatari.</em></li>
+          <li><strong>VIEWED </strong><em>Il destinatario ha letto la notifica entro il termine stabilito.</em></li>
+          <li><strong>EFFECTIVE_DATE </strong><em>Il destinatario non ha letto la notifica entro il termine stabilito.</em></li>
+          <li><strong>PAID </strong><em>Uno dei destinatari ha pagato la notifica.</em></li>
+          <li><strong>UNREACHABLE </strong><em>Il destinatario non è reperibile.</em></li>
+          <li><strong>CANCELLED </strong><em>L'ente ha annullato l'invio della notifica.</em></li>
+        </ul>
+      </details>
+    </br>
 
-    Le operazioni con il tag __Events__ sono quelle utilizzate per la lettura degli eventi 
+    Le categorie degli eventi di timeline sono i seguenti: 
+
+      <details>
+        <summary>Eventi di timeline</summary>
+        <ul>
+          <li><strong>REQUEST_REFUSED </strong><em>Richiesta di notifica rifiutata per fallimento di validazione.</em></li>
+          <li><strong>REQUEST_ACCEPTED </strong><em>Richiesta di notifica accettata a seguito dei controlli di validazione.</em></li>
+          <li><strong>SEND_COURTESY_MESSAGE </strong><em>Invio di un messaggio di cortesia.</em></li>
+          <li><strong>PUBLIC_REGISTRY_CALL </strong><em>Richiesta ai registri pubblici per ottenere domicilio digitale generale o per ottenere indirizzo fisico da ANPR, da registro della imprese, da anagrafe tributaria.</em></li>
+          <li><strong>PUBLIC_REGISTRY_RESPONSE </strong><em>Ricevuta la risposta dei registri pubblici.</em></li>
+          <li><strong>GET_ADDRESS </strong><em>Disponibilità dell’indirizzo specifico (domicilio digitale di piattaforma, domicilio digitale speciale, domicilio digitale generale, indirizzo fisico sulla notifica o sui registri nazionali).</em></li>
+          <li><strong>SCHEDULE_ANALOG_WORKFLOW </strong><em>Inizio del workflow per invio cartaceo.</em></li>
+          <li><strong>SCHEDULE_DIGITAL_WORKFLOW </strong><em>Inizio il workflow per invio digitale (PEC).</em></li>
+          <li><strong>SEND_DIGITAL_DOMICILE </strong><em>Invio digitale dell’avviso di notifica</em></li>
+          <li><strong>SEND_DIGITAL_FEEDBACK </strong><em>Ottenuto esito ad un invio digitale</em></li>
+          <li><strong>SCHEDULE_REFINEMENT </strong><em>Pianificato il perfezionamento per decorrenza termini</em></li>
+          <li><strong>REFINEMENT </strong><em>Perfezionamento per decorrenza termini</em></li>
+          <li><strong>DIGITAL_SUCCESS_WORKFLOW </strong><em>Completato con successo il workflow di invio digitale.</em></li>
+          <li><strong>DIGITAL_FAILURE_WORKFLOW </strong><em>Completato con fallimento il workflow di invio digitale. <strong>NOTA</strong>: in caso di DIGITAL_FAILURE_WORKFLOW piattaforma notifiche invia la AAR (Avviso di Avvenuta Ricezione) tramite raccomandata semplice e la notifica si considera consegnata.</em></li>
+          <li><strong>ANALOG_SUCCESS_WORKFLOW </strong><em>Completato con successo il workflow di invio cartaceo.</em></li>
+          <li><strong>ANALOG_FAILURE_WORKFLOW </strong><em>Completato con fallimento il workflow di invio cartaceo. <strong>NOTA</strong>: se per tutti i destinatari si conclude il workflow con fallimento verrà scatenato l’evento COMPLETELY_UNREACHABLE</em></li>
+          <li><strong>SEND_SIMPLE_REGISTERED_LETTER </strong><em>Invio di raccomandata semplice</em></li>
+          <li><strong>NOTIFICATION_VIEWED </strong><em>Perfezionamento per presa visione</em></li>
+          <li><strong>SEND_ANALOG_DOMICILE </strong><em>Invio cartaceo dell’avviso di notifica</em></li>
+          <li><strong>SEND_PAPER_FEEDBACK </strong><em>Ricezione esito dell'invio cartaceo</em></li>
+          <li><strong>COMPLETELY_UNREACHABLE </strong><em>Tutti i destinatari risultano irraggiungibili</em></li>
+          <li><strong>AAR_GENERATION </strong><em>Generazione dell’AAR (Avviso di Avvenuta Ricezione)</em></li>
+          <li><strong>PAYMENT </strong><em>Ricezione pagamento della notifica</em></li>
+          <li><strong>NOT_HANDLED </strong><em>Per la sperimentazione l'invio analogico non è previsto, viene inserito tale elemento di timeline</em></li>
+        </ul>
+      </details>
+    </br>
+
+    Le operazioni con il tag __Streams__ gestiscono la configurazione: <br/>
+      - [Creazione](#/Streams/createEventStream) <br/>
+      - [Elencare la lista degli stream creati](#/Streams/listEventStreams) <br/>
+      - [Leggere i metadati dello stream](#/Streams/getEventStream) <br/>
+      - [Modifica](#/Streams/updateEventStream) <br/>
+      - [Cancellazione](#/Streams/deleteEventStream) <br/>
+
+    Le operazioni con il tag __Events__ sono quelle utilizzate per la [lettura degli eventi](#/Events/consumeEventStream) 
     filtrati in base alla configurazione impostata negli streams.
     
-    La api restituisce un massimo di 100 elementi. Se ci sono ulteriori eventi nello stream sarà restituito 
-    l'elemento `retryAfter = 0`, per ottenere gli eventi successivi è necessario richiamare il servizio 
-    passando il parametro _lastEventId_ valorizzato con l'ultimo _eventId_ della richiesta precedente.
-    Questo permetterà alla piattaforma di cancellare gli eventi precedenti.
+    La api restituisce un massimo di <span id="webhookMaxLength">10</span> elementi. Se <u>esistono</u> ulteriori eventi nello stream, allora la response del servizio 
+    restituice l'elemento `retryAfter = 0`; ed è quindi possibile richiamare immediatamente il servizio per ottenere gli eventi successivi, utilizzando 
+    il parametro _lastEventId_ valorizzato con l'ultimo _eventId_ della richiesta precedente.
+    Si evidenzia che ogni nuova chiamata al servizio con _lastEventId_ implica la cancellazione degli eventi precedenti.
+    Tuttavia, in fase di implementazione del client che consumerà i servizi, bisogna considerare il fattore della __non univocità degli eventi__: è possibile che
+    se in un dato secondo avvengano più eventi contemporaneamente, nella chiamata successiva allo stream dove si inserisce l'_eventId_, non vengano cancellati
+    gli altri eventi contemporanei avvenuti nello stesso secondo dell'_eventId_ indicato; ottenendo quindi una riproposizione di eventi già ottenuti dalla chiamata precedente.</br>
+    Se <u>non esistono</u> ulteriori eventi nello stream, allora la response del servizio restituisce il valore di `retryAfter ≠ 0` ed è quindi necessario attendere il tempo indicato dalla retryAfter per consumare eventualmente nuovi eventi nello stream.</br>
+    <font color="red">__Gli eventi sono mantenuti per un massimo di <span id="webhookTtl">7</span> giorni dopo i quali sono automaticamente cancellati anche se non sono stati prelevati dallo stream, e sarà possibile ottenere lo stato della notifica solo attraverso il servizio [getNotificationRequestStatus](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/pagopa/pn-delivery/develop/docs/openapi/api-external-b2b-pa-v1.yaml#/SenderReadB2B/retrieveNotificationRequestStatus)__ </font> 
+
+    </br>
+    </br>
+    </br>
+
+    <details>
+      <summary><strong><big><big><big><big>FAQ</big></big></big></big></strong></summary>
+
+      ><details>
+      <summary><strong>Cosa devo fare se ricevo</strong> `{"message": "Unauthorized"}`<strong>?</strong></summary>
+      <em>Il messaggio indica che non sono disponibili le credenziali per utilizzare i servizi di PN. Per intraprendere il processo di accreditamento, occorre contattare il personale preposto su [account@pagopa.it](mailto:account@pagopa.it)</em>
+      </details>
+
+      ><details>
+      <summary><strong>Se creo uno stream senza filtri ad esempio</strong></br>`{ "title": "NoFilteredStream", "eventType": "STATUS", "filterValues": [] }`</br><strong> questo raccoglierà tutti i cambi di stato avvenuti nel tempo?</strong></summary>
+      <em>SI. Questo concetto è valido anche per gli eventi di TIMELINE.</em>
+      </details>
+
+      ><details>
+      <summary><strong>E' meglio avere più stream filtrati, per inquadrare specifici eventi di interesse?</strong></summary>
+      <em>SI, è consigliato generare uno o più stream applicando i filtri sugli eventi di status / timeline di maggior interesse, 
+      <font color="red"><strong>restando nel limite massimo di <span id="webhookMaxStreams">5</span> 
+      stream per PA.</font></strong></em>
+      </details>      
+
+      ><details>
+      <summary><strong>Dopo aver creato uno stream ed inserite alcune notifiche, come posso vedere gli eventi da esse generati?</strong></summary>
+      <em>Per ottenere gli eventi bisogna chiamare il servizio per la [lettura degli eventi](#/Events/consumeEventStream) inserendo nel path variabile lo _streamId_ dello stream che si vuole interrogare. A questo punto:</br>
+      >><strong>1) </strong>Se nell'header della response ottengo <strong>retry-after = 0</strong> significa che è possibile consumare ulteriori eventi presenti nello stream;</br> quindi, per ottenere gli eventi successivi dovrò richiamare nuovamente lo stesso servizio, aggiungendo come query param l'<strong>eventId</strong> dell'ultimo evento.</br></br>
+      <strong>2) </strong>Se nell'header della response ottengo <strong>retryAfter ≠ 0</strong> ed ho eventi nel body della response, significa che lo stream non contiene altri eventi e sarà necessario</br> attendere che ne siano generati di nuovi, prima di poter richiamare di nuovamente il servizio sullo stesso stream.</em></br></br>
+      </details>      
+
+      ><details>
+      <summary><strong>Posso ottenere più di <span id="webhookMaxLength">10</span> eventi da una singola chiamata?</strong></summary>
+      <em>NO, questo valore è configurato pari a <span id="webhookMaxLength">10</span> a livello applicativo e non può essere modificato.</em>
+      </details> 
+
+      ><details>
+      <summary><strong>Ho interrogato uno stream inserendo come path variabile lo _streamId_ di mio interesse ed ho ottenuto <span id="webhookMaxLength">10</span> eventi, ognuno con il proprio _eventId_. Ho richiamato di nuovo lo stesso servizio aggiungendo come query param l'_eventId_ dell'ultimo evento ottenuto nella prima chiamata ed ottengo gli eventi successivi a quelli ottenuti nella prima chiamata. Posso vedere di nuovo gli eventi ottenuti dalla prima chiamata?</strong></summary>
+      <em>NO, una volta passato il query param __eventId__ alla chiamata del servizio, tutti gli eventi precedenti sono cancellati dallo stream e non possono più essere recuperati. E' quindi fondamentale salvare gli eventi ottenuti da ogni chiamata, prima di richiedere i successivi.</em></br></br>
+      </details> 
+
+      ><details><summary><strong>Per quanto tempo gli eventi restano registrati su uno stream?</strong></summary><em>Gli eventi restano registrati su uno stream per <strong><span id="webhookTtl">7</span> 
+      giorni</strong>, trascorsi i quali non potranno più essere recuperati. A questo punto sarà possibile ottenere lo stato della notifica solo attraverso il servizio puntuale [getNotificationRequestStatus](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/pagopa/pn-delivery/develop/docs/openapi/api-external-b2b-pa-v1.yaml#/SenderReadB2B/retrieveNotificationRequestStatus), mentre se si conosce lo IUN si può utilizzare il servizio [getSentNotification](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/pagopa/pn-delivery/develop/docs/openapi/api-external-b2b-pa-v1.yaml#/SenderReadB2B/retrieveSentNotification) per leggere tutti i dettagli di una notifica accettata</em></details>
+
+    </details>
+
     
-    Gli eventi sono mantenuti per un massimo di X giorni dopo i quali sono automaticamente cancellati anche
-    se non sono stati prelevati dallo stream.
 
   contact:
-    email: pn@pagopa.it
+    email: pn-supporto-enti@pagopa.it
   license:
     name: Licenza di PN
-    url: 'https://da-definire/'
+    url: 'https://notifichedigitali.pagopa.it/pubbliche-amministrazioni/index.html'
 servers:
 - url: https://api.pn.pagopa.it
   description: Ambiente di produzione
@@ -274,7 +407,7 @@ paths:
                 type: integer
                 format: int32
               description: >-
-                Numero di secondi di attesa prima di effettuare una nuova lettura di eventi. <br/>
+                Numero di millisecondi di attesa prima di effettuare una nuova lettura di eventi. <br/>
                 Sarà valorizzato a zero se ci sono eventi in coda che non sono stati forniti per 
                 raggiunta dimensione massima della risposta. <br/>
                 Sarà maggiore di zero se gli eventi in coda sono stati tutti inviati.
@@ -290,7 +423,7 @@ paths:
                 type: integer
                 format: int32
               description: >-
-                Numero di secondi di attesa prima di effettuare una nuova lettura di eventi.
+                Numero di millisecondi di attesa prima di effettuare una nuova lettura di eventi.
         '400':
           description: Invalid input
           content:
@@ -489,7 +622,7 @@ components:
           type: string
         iun:
           description: >-
-            Identificativo della notifica, presente solo se la richiesta di notifica è
+            Identificativo della notifica, presente solo se la richiesta di notifica è 
             stata accettata.
           type: string
 
@@ -514,7 +647,7 @@ components:
           type: array                                                                   # NOT YET IMPLEMENTED
           items:                                                                        # NOT YET IMPLEMENTED
             $ref: '#/components/schemas/ExternalEvent'                                  # NOT YET IMPLEMENTED
-    
+
     ExternalEvent:                                                                      # NOT YET IMPLEMENTED
       title: Un evento generato all'esterno di PN.                                      # NOT YET IMPLEMENTED
       description: >-                                                                   # NOT YET IMPLEMENTED

--- a/docs/openapi/schemas-pn-status-v1.yaml
+++ b/docs/openapi/schemas-pn-status-v1.yaml
@@ -17,27 +17,27 @@ components:
       type: string
       description: >
         stato di avanzamento del processo di notifica:
-          * `IN_VALIDATION` - notifica in attesa di validazione
-          * `ACCEPTED` - notifica accettata 
-          * `REFUSED` - notifica rifiutata
-          * `DELIVERING` - invio della notifica in corso
-          * `DELIVERED` - notifica ricevuta da tutti i destinatari
-          * `VIEWED` - notifica perfezionata per presa visione da almeno un destinatario
-          * `EFFECTIVE_DATE` - notifica perfezionata per decorrenza termini per un destinatario
-          * `PAID` - notifica pagata
-          * `UNREACHABLE` - notifica non recapitabile per tutti i destintari
-          * `CANCELLED` - notifica annullata dal mittente
+          * `IN_VALIDATION` - notifica depositata in attesa di validazione
+          * `ACCEPTED` - L'ente ha depositato la notifica con successo
+          * `REFUSED` - Notifica rifiutata a seguito della validazione
+          * `DELIVERING` - L'invio della notifica è in corso
+          * `DELIVERED` - La notifica è stata consegnata a tutti i destinatari
+          * `VIEWED` - Il destinatario ha letto la notifica entro il termine stabilito
+          * `EFFECTIVE_DATE` - Il destinatario non ha letto la notifica entro il termine stabilito
+          * `PAID` - Uno dei destinatari ha pagato la notifica
+          * `UNREACHABLE` - Il destinatario non è reperibile
+          * `CANCELLED` - L'ente ha annullato l'invio della notifica
       enum:
-        - IN_VALIDATION
-        - ACCEPTED
-        - DELIVERING
-        - DELIVERED
-        - VIEWED
-        - EFFECTIVE_DATE
-        - PAID
-        - UNREACHABLE
-        - REFUSED
-        - CANCELLED
+        - IN_VALIDATION 
+        - ACCEPTED 
+        - REFUSED 
+        - DELIVERING 
+        - DELIVERED 
+        - VIEWED 
+        - EFFECTIVE_DATE 
+        - PAID 
+        - UNREACHABLE 
+        - CANCELLED 
     
     NotificationStatusHistory: 
       description: elenco degli avanzamenti effettuati dal processo di notifica


### PR DESCRIPTION
+ api-internal-b2b-webhook-v1.yaml
	- Aggiunte i seguenti span con id appropriato sulle seguenti variabili:
		* 10 pn.delivery-push.webhook.max-length = lunghezza massima della response degli eventi
		* 5 pn.delivery-push.webhook.max-streams = numero massimo di stram confgurabili per PA
		* 7 pn.delivery-push.webhook.ttl = retention per gli eventi webhook PN-2264
		per il valore retry after, non inserita varabile poichè inserito
retryAfter = 0 e retryAfter ≠ 0 su tutte le occorrenze, così restano valide anche in caso di modifiche del valore retryAfter in futuro.
		Aggiunti commenti in cima al file per descrivere le variabili e
permetterne la modifica in futuro in modo rapido
	- aggiornato puntamento ai termini di servizio, all'email di supporto enti e all'url della license
	- aggiunta la FAQ del forbidden che indirizza alla mail dell'onboarding
	- aggiunte altre FAQ sulle domande più frequenti ricevute nei giorni scorsi
	- inserito l'elenco di stati ed eventi di timeline in formato collapsible nella descrizione
	- aggiunti altri 2 esempi di creazione degli stream con filtri
	- inseriti i link nella descrizione che puntano alle API descritte successivamente
	- inserita l'indicazione che le stream vengono cancellate dopo 7 giorni con relativa FAQ citando i servizi da usare dopo i 7 gg: retrieveNotificationRequestStatus per ottenere lo stato della notifica retrieveSentNotification per leggere tutti i dettagli di una notifica accettata con relativo puntamento alle descrizioni degli stessi
+ api-external-b2b-webhook-v1.yaml
	- eseeguito script internal-to-external per allineare i file
+ schemas pn-status
	- modificate le descrizioni per migliorare la leggibilirà ed oridinato l'enum in base allo stesso ordine delle descrizioni