### PR TITLE
aggiornamento swagger

### DIFF
--- a/docs/openapi/api-external-b2b-webhook-v1.yaml
+++ b/docs/openapi/api-external-b2b-webhook-v1.yaml
@@ -11,7 +11,7 @@ info:
   x-api-id: api-external-b2b-webhook # ONLY EXTERNAL
   description: >- 
     I mittenti di notifica possono seguire il flusso di avanzamento delle notifiche in modo 
-    automatico. E' possibile definire fino ad un <font color="red"><strong>massimo di <span id="webhookMaxStreams">5</span> configurazioni di flussi</strong></font> per 
+    automatico. E' possibile definire fino ad un <font color="red"><strong>massimo di <span id="webhookMaxStreams">5</span> configurazioni di flussi per singola PA</strong></font> su 
     informazioni relative a: <br/>
       - cambiamento di stato della notifica;  <br/>
       - inserimento di elementi nella timeline. <br/>
@@ -175,6 +175,36 @@ info:
 
       ><details><summary><strong>Per quanto tempo gli eventi restano registrati su uno stream?</strong></summary><em>Gli eventi restano registrati su uno stream per <strong><span id="webhookTtl">7</span> 
       giorni</strong>, trascorsi i quali non potranno più essere recuperati. A questo punto sarà possibile ottenere lo stato della notifica solo attraverso il servizio puntuale [getNotificationRequestStatus](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/pagopa/pn-delivery/develop/docs/openapi/api-external-b2b-pa-v1.yaml#/SenderReadB2B/retrieveNotificationRequestStatus), mentre se si conosce lo IUN si può utilizzare il servizio [getSentNotification](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/pagopa/pn-delivery/develop/docs/openapi/api-external-b2b-pa-v1.yaml#/SenderReadB2B/retrieveSentNotification) per leggere tutti i dettagli di una notifica accettata</em></details>
+      
+      ><details>
+      <summary><strong>Come faccio a capire il canale di spedizione seguito da una notifica?</strong></summary>
+      <em>Gli eventi di workflow sono differenti a seconda che il canale di spedizione sia digitale o analogico, ad esempio <strong>SCHEDULE_ANALOG_WORKFLOW</strong> determina l'inizio del workflow per invio cartaceo mentre <strong>SCHEDULE_DIGITAL_WORKFLOW</strong> per l'invio digitale.</br> In base all'evento presente nello stream sarà quindi possibile dedurre il canale di spedizione utilizzato.</em>
+      </details>
+      
+      ><details>
+      <summary><strong>In caso di destinatario multiplo, che significato ha lo stato della notifica?</strong></summary>
+      <em>Lo stato della notifica è unico per la notifica stessa ed i destinatari multipli si intedono come co-obbigati; questo significa che:</em>
+      ><ul>
+      <li><small><em>lo stato è <strong>Depositata</strong> quando viene depositata dalla PA.</em></small></li>
+      <li><small><em>lo stato è <strong>Invio in corso</strong> quando la notifica inizia il processo di spedizione per almeno un destinatario.</em></small></li>
+      <li><small><em>lo stato è <strong>Consegnata</strong> quando il processo di spedizione è terminato per tutti ed almeno uno dei destinatari è stato raggiunto.</em></small></li>
+      <li><small><em>lo stato è <strong>Irreperibile</strong> quando non è stato possibile raggiungere nessuno dei destinatari.</em></small></li>
+      <li><small><em>lo stato è <strong>Visualizzata</strong> quando almeno un destinatario ha acceduto agli atti della notifica. </em></small></li>
+      <li><small><em>lo stato è <strong>Perfezionata per decorrenza termini</strong> quando si perfeziona per decorrenza termini (a norma di legge) per almeno un destinatario e se nessuno dei destinatari ha preso visione della notifica stessa.</em></small></li>
+      <li><small><em>lo stato è <strong>Pagata</strong> quando uno dei destinatari ha completato con successo il pagamento.</em></small></li>
+      <li><small><em>lo stato è <strong>Annullata</strong> quando la notifica viene annullata da una PA creandone una nuova.</em></small></li>
+      </ul>
+      </details>
+      
+      ><details>
+      <summary><strong>In caso di destinatario multiplo, che significato ha un evento di timeline?</strong></summary>
+      <em>Quando sono presenti destinatari multipli, ogni evento di timeline sarà specifico per ogni destinatario ed appariranno tutti nella timeline con l'indicazione del destinatario impattato dall'evento.</em>
+      </details>
+      
+      ><details>
+      <summary><strong>In caso di destinatario multiplo, ricevo un'attestazione opponibile per ogni destinatario?</strong></summary>
+      <em>NO, le attestazione opponibile ai terzi vengono generate al verificarsi di alcuni eventi rilevanti per la notificazione e di conseguenza avrò un'unca attestazione dello stesso tipo, per notifica.</em>
+      </details>
 
     </details>
 

--- a/docs/openapi/api-internal-b2b-webhook-v1.yaml
+++ b/docs/openapi/api-internal-b2b-webhook-v1.yaml
@@ -12,7 +12,7 @@ info:
 #  x-api-id: api-external-b2b-webhook # ONLY EXTERNAL
   description: >- 
     I mittenti di notifica possono seguire il flusso di avanzamento delle notifiche in modo 
-    automatico. E' possibile definire fino ad un <font color="red"><strong>massimo di <span id="webhookMaxStreams">5</span> configurazioni di flussi</strong></font> per 
+    automatico. E' possibile definire fino ad un <font color="red"><strong>massimo di <span id="webhookMaxStreams">5</span> configurazioni di flussi per singola PA</strong></font> su 
     informazioni relative a: <br/>
       - cambiamento di stato della notifica;  <br/>
       - inserimento di elementi nella timeline. <br/>
@@ -176,6 +176,36 @@ info:
 
       ><details><summary><strong>Per quanto tempo gli eventi restano registrati su uno stream?</strong></summary><em>Gli eventi restano registrati su uno stream per <strong><span id="webhookTtl">7</span> 
       giorni</strong>, trascorsi i quali non potranno più essere recuperati. A questo punto sarà possibile ottenere lo stato della notifica solo attraverso il servizio puntuale [getNotificationRequestStatus](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/pagopa/pn-delivery/develop/docs/openapi/api-external-b2b-pa-v1.yaml#/SenderReadB2B/retrieveNotificationRequestStatus), mentre se si conosce lo IUN si può utilizzare il servizio [getSentNotification](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/pagopa/pn-delivery/develop/docs/openapi/api-external-b2b-pa-v1.yaml#/SenderReadB2B/retrieveSentNotification) per leggere tutti i dettagli di una notifica accettata</em></details>
+      
+      ><details>
+      <summary><strong>Come faccio a capire il canale di spedizione seguito da una notifica?</strong></summary>
+      <em>Gli eventi di workflow sono differenti a seconda che il canale di spedizione sia digitale o analogico, ad esempio <strong>SCHEDULE_ANALOG_WORKFLOW</strong> determina l'inizio del workflow per invio cartaceo mentre <strong>SCHEDULE_DIGITAL_WORKFLOW</strong> per l'invio digitale.</br> In base all'evento presente nello stream sarà quindi possibile dedurre il canale di spedizione utilizzato.</em>
+      </details>
+      
+      ><details>
+      <summary><strong>In caso di destinatario multiplo, che significato ha lo stato della notifica?</strong></summary>
+      <em>Lo stato della notifica è unico per la notifica stessa ed i destinatari multipli si intedono come co-obbigati; questo significa che:</em>
+      ><ul>
+      <li><small><em>lo stato è <strong>Depositata</strong> quando viene depositata dalla PA.</em></small></li>
+      <li><small><em>lo stato è <strong>Invio in corso</strong> quando la notifica inizia il processo di spedizione per almeno un destinatario.</em></small></li>
+      <li><small><em>lo stato è <strong>Consegnata</strong> quando il processo di spedizione è terminato per tutti ed almeno uno dei destinatari è stato raggiunto.</em></small></li>
+      <li><small><em>lo stato è <strong>Irreperibile</strong> quando non è stato possibile raggiungere nessuno dei destinatari.</em></small></li>
+      <li><small><em>lo stato è <strong>Visualizzata</strong> quando almeno un destinatario ha acceduto agli atti della notifica. </em></small></li>
+      <li><small><em>lo stato è <strong>Perfezionata per decorrenza termini</strong> quando si perfeziona per decorrenza termini (a norma di legge) per almeno un destinatario e se nessuno dei destinatari ha preso visione della notifica stessa.</em></small></li>
+      <li><small><em>lo stato è <strong>Pagata</strong> quando uno dei destinatari ha completato con successo il pagamento.</em></small></li>
+      <li><small><em>lo stato è <strong>Annullata</strong> quando la notifica viene annullata da una PA creandone una nuova.</em></small></li>
+      </ul>
+      </details>
+      
+      ><details>
+      <summary><strong>In caso di destinatario multiplo, che significato ha un evento di timeline?</strong></summary>
+      <em>Quando sono presenti destinatari multipli, ogni evento di timeline sarà specifico per ogni destinatario ed appariranno tutti nella timeline con l'indicazione del destinatario impattato dall'evento.</em>
+      </details>
+      
+      ><details>
+      <summary><strong>In caso di destinatario multiplo, ricevo un'attestazione opponibile per ogni destinatario?</strong></summary>
+      <em>NO, le attestazione opponibile ai terzi vengono generate al verificarsi di alcuni eventi rilevanti per la notificazione e di conseguenza avrò un'unca attestazione dello stesso tipo, per notifica.</em>
+      </details>
 
     </details>
 


### PR DESCRIPTION
- inserita indicazione esplicita del limite delle stream per PA
- inserite 3 FAQ sul multi-destinatario ed 1 sul canale di spedizione in seguito ai dubbi di INPS
(di seguito le FAQ inserite per facilitarne la lettura)

**1. D) come faccio a capire il canale di spedizione seguito da una notifica?**
R) Gli eventi di workflow sono differenti a seconda che il canale di spedizione sia digitale o analogico, ad esempio **SCHEDULE_ANALOG_WORKFLOW** determina l'inizio del workflow per invio cartaceo mentre **SCHEDULE_DIGITAL_WORKFLOW** per l'invio digitale. In base all'evento presente nello stream sarà quindi possibile dedurre il canale di spedizione utilizzato.

**2. D) In caso di destinatario multiplo, che significato ha lo stato della notifica?**
R) Lo stato della notifica è unico per la notifica stessa ed i destinatari multipli si intedono come co-obbigati; questo significa che:
       - lo stato è **Depositata** quando viene depositata dalla PA.
       - lo stato è **Invio in corso** quando la notifica inizia il processo di spedizione per almeno un destinatario.
       - lo stato è **Consegnata** quando il processo di spedizione è terminato per tutti ed almeno uno dei destinatari è stato raggiunto.
       - lo stato è **Irreperibile** quando non è stato possibile raggiungere nessuno dei destinatari.
       - lo stato è **Visualizzata** quando almeno un destinatario ha acceduto agli atti della notifica. 
       - lo stato è **Perfezionata per decorrenza termini** quando si perfeziona per decorrenza termini (a norma di legge) per almeno un destinatario e se nessuno dei destinatari ha preso visione della notifica stessa. 
       - lo stato è **Pagata** quando uno dei destinatari ha completato con successo il pagamento.
       - lo stato è **Annullata** quando la notifica viene annullata da una PA creandone una nuova.

**3. D) In caso di destinatario multiplo, che significato ha un evento di timeline?**
R) Quando sono presenti destinatari multipli, ogni evento di timeline sarà specifico per ogni destinatario ed appariranno tutti nella timeline con l'indicazione del destinatario impattato dall'evento.

**4. D) In caso di destinatario multiplo, ricevo un'attestazione opponibile per ogni destinatario?**
R) NO, le attestazione opponibile ai terzi vengono generate al verificarsi di alcuni eventi rilevanti per la notificazione e di conseguenza avrò un'unica attestazione dello stesso tipo, per notifica.