### PR TITLE
PN-3013 parent version to 2.0.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
 	<parent>
 		<groupId>it.pagopa.pn</groupId>
 		<artifactId>pn-parent</artifactId>
-		<version>1.0.1-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 	<groupId>it.pagopa.pn.delivery</groupId>
 	<artifactId>pn-delivery-push</artifactId>
-	<version>1.0.2-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<name>pn-delivery-push</name>
 	<description>Orchestrate Notification Workflow</description>
 	<scm>
@@ -27,13 +27,13 @@
 		<dependency>
 			<groupId>it.pagopa.pn</groupId>
 			<artifactId>pn-model</artifactId>
-			<version>1.0.1-SNAPSHOT</version>
+			<version>2.0.0-SNAPSHOT</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>it.pagopa.pn</groupId>
 			<artifactId>pn-commons</artifactId>
-			<version>1.0.1-SNAPSHOT</version>
+			<version>2.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
@@ -105,22 +105,11 @@
 			<version>5.11.1</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.mock-server</groupId>
-			<artifactId>mockserver-netty</artifactId>
-			<version>5.11.0</version>
-			<scope>test</scope>
-		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>software.amazon.awssdk</groupId>
-			<artifactId>dynamodb-enhanced</artifactId>
-			<version>2.18.6</version>
 		</dependency>
 		<dependency>
 			<groupId>net.javacrumbs.shedlock</groupId>

--- a/src/main/java/it/pagopa/pn/deliverypush/middleware/dao/webhook/dynamo/entity/StreamEntity.java
+++ b/src/main/java/it/pagopa/pn/deliverypush/middleware/dao/webhook/dynamo/entity/StreamEntity.java
@@ -2,7 +2,6 @@ package it.pagopa.pn.deliverypush.middleware.dao.webhook.dynamo.entity;
 
 import lombok.Data;
 import lombok.Getter;
-import software.amazon.awssdk.enhanced.dynamodb.extensions.annotations.DynamoDbAtomicCounter;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.UpdateBehavior;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.*;
 


### PR DESCRIPTION
- Java 17
- Spring Boot 2.7.6
- eliminata dipendenza transitiva mockserver-netty (è già contenuta in mockserver-junit-jupiter)
- eliminata doppia dipendenza dynamodb-enhanced (era presente 2 volte nel pom)