### PR TITLE
fix: adds <br/> tag before delivery disclaimer PecDeliveryWorkflowLegalFact.html

### DIFF
--- a/src/main/resources/documents_composition_templates/PecDeliveryWorkflowLegalFact.html
+++ b/src/main/resources/documents_composition_templates/PecDeliveryWorkflowLegalFact.html
@@ -208,7 +208,7 @@
       </div>
       <#if delivery.ok>
       <div class="paragraph">
-        il relativo avviso di avvenuta ricezione in formato elettronico è stato consegnato in data <strong>${delivery.responseDate}</strong>.
+        il relativo avviso di avvenuta ricezione in formato elettronico è stato consegnato in data <br/><strong>${delivery.responseDate}</strong>.
       </div>
       <#else>
       <div class="paragraph">


### PR DESCRIPTION
### Description
Prevents delivery.responseDate from being split by newline