### PR TITLE
PN-4725 - define and use precise link to 'completion moment' inside FAQ of landing site

### DIFF
--- a/src/main/java/it/pagopa/pn/deliverypush/PnDeliveryPushConfigs.java
+++ b/src/main/java/it/pagopa/pn/deliverypush/PnDeliveryPushConfigs.java
@@ -164,6 +164,7 @@ public class PnDeliveryPushConfigs {
         private String directAccessUrlTemplatePhysical;
         private String directAccessUrlTemplateLegal;
         private String faqUrlTemplateSuffix;
+        private String faqCompletionMomentHash;
         private String quickAccessUrlAarDetailSuffix;
         private String landingUrl;
    }

--- a/src/main/java/it/pagopa/pn/deliverypush/legalfacts/LegalFactGenerator.java
+++ b/src/main/java/it/pagopa/pn/deliverypush/legalfacts/LegalFactGenerator.java
@@ -55,6 +55,7 @@ public class LegalFactGenerator {
     public static final String FIELD_PIATTAFORMA_NOTIFICHE_URL = "piattaformaNotificheURL";
     public static final String FIELD_PIATTAFORMA_NOTIFICHE_URL_LABEL = "piattaformaNotificheURLLabel";
     public static final String FIELD_PN_FAQ_URL = "PNFaqURL";
+    public static final String FIELD_PN_FAQ_COMPLETION_MOMENT_URL = "PNFaqCompletionMomentURL";
     public static final String FIELD_END_WORKFLOW_STATUS = "endWorkflowStatus";
     public static final String FIELD_END_WORKFLOW_DATE = "endWorkflowDate";
     public static final String FIELD_LEGALFACT_CREATION_DATE = "legalFactCreationDate";
@@ -334,6 +335,7 @@ public class LegalFactGenerator {
         templateModel.put(FIELD_PIATTAFORMA_NOTIFICHE_URL, this.getAccessUrl(recipient) );
         templateModel.put(FIELD_PIATTAFORMA_NOTIFICHE_URL_LABEL, this.getAccessUrlLabel(recipient) );
         templateModel.put(FIELD_PN_FAQ_URL, this.getFAQAccessLink());
+        templateModel.put(FIELD_PN_FAQ_COMPLETION_MOMENT_URL, this.getFAQCompletionMomentAccessLink());
         templateModel.put(FIELD_QUICK_ACCESS_LINK, this.getQuickAccessLink(recipient, quickAccesstoken) );
         templateModel.put(FIELD_RECIPIENT_TYPE, this.getRecipientTypeForHTMLTemplate(recipient));
 
@@ -373,7 +375,11 @@ public class LegalFactGenerator {
     }
 
     private String getFAQAccessLink() {
-        return pnDeliveryPushConfigs.getWebapp().getLandingUrl() + pnDeliveryPushConfigs.getWebapp().getFaqUrlTemplateSuffix();
+        return pnDeliveryPushConfigs.getWebapp().getLandingUrl() + "/" + pnDeliveryPushConfigs.getWebapp().getFaqUrlTemplateSuffix();
+    }
+
+    private String getFAQCompletionMomentAccessLink() {
+        return this.getFAQAccessLink() + "#" + pnDeliveryPushConfigs.getWebapp().getFaqCompletionMomentHash();
     }
 
     private String getRecipientTypeForHTMLTemplate(NotificationRecipientInt recipientInt) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,6 +24,8 @@ pn.delivery-push.external-channel-cx-id=pn-delivery-002
 pn.legalfacts.generator=OPENHTML2PDF
 
 pn.delivery-push.webapp.landing-url=https://notifichedigitali.pagopa.it
+pn.delivery-push.webapp.faqUrlTemplateSuffix=faq
+pn.delivery-push.webapp.faqCompletionMomentHash=perfezionamento-quando
 
 pn.delivery-push.paper-channel.sender-address.fullname=PagoPA S.p.A.
 pn.delivery-push.paper-channel.sender-address.address=Via Sardegna n. 38

--- a/src/main/resources/documents_composition_templates/NotificationAARForEMAIL.html
+++ b/src/main/resources/documents_composition_templates/NotificationAARForEMAIL.html
@@ -215,7 +215,7 @@
                                                         <p>Ciao,</p>
                                                         <p>Hai ricevuto su SEND - Servizio Notifiche Digitali una notifica da parte di <strong>${notification.sender.paDenomination}</strong> con Codice IUN <strong>${notification.iun}</strong>. Una notifica è una <strong>comunicazione a valore legale</strong> composta da una avviso di avvenuta ricezione e da uno o più documenti.</p>
                                                         <!-- Perfezionamento Notifica -->
-                                                        <p>Hai fino a 120 dalla <a href="${PNFaqURL}" class="link" style="color: #0073E6">data di perfezionamento</a> della notifica per <strong>visualizzare i documenti</strong>.</p>
+                                                        <p>Hai fino a 120 dalla <a href="${PNFaqCompletionMomentURL}" class="link" style="color: #0073E6">data di perfezionamento</a> della notifica per <strong>visualizzare i documenti</strong>.</p>
                                                         <a title="Visualizza documenti" class="button" href="${piattaformaNotificheURL}">Visualizza documenti</a>
                                                         <!--  Avviso su PEC -->
                                                         <p>Se non hai una PEC e visualizzi i documenti entro 5 giorni (120 ore) dall’invio del messaggio, non riceverai l'avviso di avvenuta ricezione tramite raccomandata.</p>

--- a/src/main/resources/documents_composition_templates/NotificationAARForPEC.html
+++ b/src/main/resources/documents_composition_templates/NotificationAARForPEC.html
@@ -225,7 +225,7 @@
                                                         <p>Ciao,</p>
                                                         <p>Hai ricevuto su SEND - Servizio Notifiche Digitali una notifica da parte di <strong>${notification.sender.paDenomination}</strong>. Una notifica è una <strong>comunicazione a valore legale</strong> composta da un avviso di avvenuta ricezione e da uno o più documenti.</p>
                                                         <!-- Perfezionamento Notifica -->
-                                                        <p>Hai fino a 120 giorni dalla <a href="${PNFaqURL}" class="link" style="color: #0073E6">data di perfezionamento</a> della notifica per <strong>visualizzare i documenti</strong>.</p>
+                                                        <p>Hai fino a 120 giorni dalla <a href="${PNFaqCompletionMomentURL}" class="link" style="color: #0073E6">data di perfezionamento</a> della notifica per <strong>visualizzare i documenti</strong>.</p>
                                                         <a title="Visualizza i documenti" href="${quickAccessLink}" class="button">Visualizza i documenti</a>
                                                         <p><strong>Preferisci ritirali in Ufficio Postale?</strong> Segui le indicazioni che trovi nell'allegato.</p>
                                                         <p style="font-family: Titillium Web, Arial;font-weight: 400;font-size: 14px;">


### PR DESCRIPTION
The link points to a specific hash inside the (new) FAQ page of the landing site. It is used in a link present in both AAR HTMLs, for email and for PEC.